### PR TITLE
Adding long_description_content_type to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     url="https://github.com/scriptsrc/flagpole",
     description="Flagpole is a Flag arg parser to build out a dictionary with optional keys.",
     long_description=open(os.path.join(ROOT, "README.md")).read(),
+    long_description_content_type="text/markdown",
     packages=["flagpole"],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Pypi is rejecting the new version without this:

```
Submitting dist/flagpole-1.1.1.tar.gz to https://upload.pypi.org/legacy/
Upload failed (400): The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
```